### PR TITLE
Now all cameras are resized with the AndroidTV UI

### DIFF
--- a/Assets/AirConsole/scripts/AirConsole.cs
+++ b/Assets/AirConsole/scripts/AirConsole.cs
@@ -1834,8 +1834,9 @@ namespace NDream.AirConsole {
 			}
 
 			webViewObject.SetMargins(0, 0, 0, defaultScreenHeight - webViewHeight);
-			if (androidUIResizeMode == AndroidUIResizeMode.ResizeCamera  || androidUIResizeMode == AndroidUIResizeMode.ResizeCameraAndReferenceResolution) {
-				Camera.main.pixelRect = new Rect (0, 0, Screen.width, Screen.height - GetScaledWebViewHeight());
+			if (androidUIResizeMode == AndroidUIResizeMode.ResizeCamera  || androidUIResizeMode == AndroidUIResizeMode.ResizeCameraAndReferenceResolution)
+			{
+				ResizeCamerasWithAndroidUI();
 			}
         }
 
@@ -1843,13 +1844,21 @@ namespace NDream.AirConsole {
 			webViewObject.SetMargins(0, 0, 0, 0);
 		}
 
+        private void ResizeCamerasWithAndroidUI()
+        {
+	        foreach (var cam in Camera.allCameras)
+	        {
+		        cam.pixelRect = new Rect (0, 0, Screen.width, Screen.height - GetScaledWebViewHeight()); 
+	        }
+        }
+
 		private void OnSceneLoaded(Scene scene, LoadSceneMode sceneMode) {
 			if (instance != this) {
 				return;
 			}
 
 			if (androidUIResizeMode == AndroidUIResizeMode.ResizeCamera  || androidUIResizeMode == AndroidUIResizeMode.ResizeCameraAndReferenceResolution) {
-				Camera.main.pixelRect = new Rect(0, 0, Screen.width, Screen.height - GetScaledWebViewHeight());
+				ResizeCamerasWithAndroidUI();
 			}
 
 			if (androidUIResizeMode == AndroidUIResizeMode.ResizeCameraAndReferenceResolution) {


### PR DESCRIPTION
I was porting my game "com.ecantalejos.rgbblocks" to Android TV and I had problems with the "Android UI resize mode" because I have a nested scene with "another Main.camera" in the nested one.

So I changed only resizing the Camera.pixelRect from Main.camera to resize all the cameras with the AndroidUI in mind.