### PR TITLE
Update persistent data api

### DIFF
--- a/Assets/AirConsole/scripts/AirConsole.cs
+++ b/Assets/AirConsole/scripts/AirConsole.cs
@@ -948,13 +948,19 @@ namespace NDream.AirConsole {
 		/// Requests persistent data from the servers.
 		/// Will call onPersistentDataLoaded when data was received.
 		/// </summary>
-		/// <param name="uids">The uids for which you would like to request the persistent data. Default is this device.</param>
-		public void RequestPersistentData (List<string> uids = null) {
+		/// <param name="uids">The uids for which you would like to request the persistent data.</param>
+		public void RequestPersistentData(List<string> uids) {
 
 			if (!IsAirConsoleUnityPluginReady ()) {
-
 				throw new NotReadyException ();
+			}
 
+			if (uids == null) {
+				throw new ArgumentNullException("uids");
+			}
+
+			if (uids.Count < 1) {
+				throw new ArgumentException("uids must contain at least one uid");
 			}
 
 			JObject msg = new JObject ();
@@ -980,13 +986,15 @@ namespace NDream.AirConsole {
 		/// </summary>
 		/// <param name="key">The key of the data entry.</param>
 		/// <param name="value">The value of the data entry.</param>
-		/// <param name="uid">The uid for which the data should be stored. Default is this device.</param>
-		public void StorePersistentData (string key, JToken value, string uid = null) {
+		/// <param name="uid">The uid for which the data should be stored.</param>
+		public void StorePersistentData(string key, JToken value, string uid) {
 
 			if (!IsAirConsoleUnityPluginReady ()) {
-
 				throw new NotReadyException ();
+			}
 
+			if (string.IsNullOrEmpty(uid)) {
+				throw new ArgumentException("uid must not be null or empty");
 			}
 
 			JObject msg = new JObject ();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [2.5.0]
+
+### Changed
+- StorePersistentData's uid parameter is no longer optional.
+- RequestPersistentData's uids parameter is no longer optional.
+
+
 ## [2.14] - 2022-11-02
 
 ### New Features


### PR DESCRIPTION
This makes the uid a required parameter in the RequestPersistentData and StorePersistentData methods

This will be released as part of AirConsole Unity Plugin 2.5.0 along the other API changes to make it possible to provide version migration documentation on https://developers.airconsole.com ahead of release.

This is the Unity part of https://github.com/AirConsole/airconsole-api/pull/78

This PR will not be merged until the validation based on https://github.com/AirConsole/airconsole-appengine/pull/2432 has concluded.