### PR TITLE
Add Unity 2019 webgl build support

### DIFF
--- a/Assets/AirConsole/scripts/Settings.cs
+++ b/Assets/AirConsole/scripts/Settings.cs
@@ -8,7 +8,7 @@ namespace NDream.AirConsole {
 		public const string AIRCONSOLE_BASE_URL = "https://www.airconsole.com/";
 		public const string AIRCONSOLE_DEV_URL_HTTPS = "https://www.airconsole.com/";
 		public const string AIRCONSOLE_DEV_URL_HTTP = "http://http.airconsole.com/";
-		
+
 		public const string AIRCONSOLE_PROFILE_PICTURE_URL = "https://www.airconsole.com/api/profile-picture?uid=";
 		public const string WEBSOCKET_PATH = "/api";
 		public const int DEFAULT_WEBSERVER_PORT = 7842;
@@ -16,6 +16,7 @@ namespace NDream.AirConsole {
 		public static int webServerPort = 7842;
 		public static int webSocketPort = 7843;
 		public static DebugLevel debug = new DebugLevel ();
+		public static string Python2Path = "/usr/local/bin/python2";
 
 		public static readonly string WEBTEMPLATE_PATH;
 

--- a/Assets/AirConsole/scripts/editor/Extentions.cs
+++ b/Assets/AirConsole/scripts/editor/Extentions.cs
@@ -74,6 +74,9 @@ namespace NDream.AirConsole.Editor {
 				Settings.debug.error = EditorPrefs.GetBool ("debugError");
 			}
 
+			if (EditorPrefs.GetString("python2Path", "") != "") {
+				Settings.Python2Path = EditorPrefs.GetString("python2Path");
+			}
 		}
 
 		public static void ResetDefaultValues () {

--- a/Assets/AirConsole/scripts/editor/SettingWindow.cs
+++ b/Assets/AirConsole/scripts/editor/SettingWindow.cs
@@ -80,8 +80,14 @@ namespace NDream.AirConsole.Editor {
 
 			EditorGUILayout.EndToggleGroup ();
 
+
+			EditorGUILayout.BeginHorizontal();
+			Settings.Python2Path = EditorGUILayout.TextField("Python 2 Path", Settings.Python2Path, GUILayout.MinWidth(600));
+			EditorPrefs.SetString("python2Path", Settings.Python2Path);
+			GUILayout.EndHorizontal();
+
 			EditorGUILayout.BeginHorizontal (styleBlack);
-            
+
 			GUILayout.FlexibleSpace ();
 			if (GUILayout.Button ("Reset Settings", GUILayout.MaxWidth (110))) {
 				Extentions.ResetDefaultValues ();

--- a/Assets/Editor/PreBuildProcessing.cs
+++ b/Assets/Editor/PreBuildProcessing.cs
@@ -1,11 +1,12 @@
 #if UNITY_EDITOR
-using UnityEditor;
+using NDream.AirConsole;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
 
 public class PreBuildProcessing : IPreprocessBuildWithReport {
     public int callbackOrder => 1;
+
     public void OnPreprocessBuild(BuildReport report) {
         Debug.Log("Used Python path: " + System.Environment.GetEnvironmentVariable("EMSDK_PYTHON"));
 
@@ -16,7 +17,9 @@ public class PreBuildProcessing : IPreprocessBuildWithReport {
 
         // If you need to set the Python path manually you can use the code below, uncomment it and
         // set "EMSDK_PYTHON" to the the Python 3 (Or Python 2 for old Unity versions) path:
-        // System.Environment.SetEnvironmentVariable("EMSDK_PYTHON", "<python-path-here>");
+#if !UNITY_2020_1_OR_NEWER
+        System.Environment.SetEnvironmentVariable("EMSDK_PYTHON", Settings.Python2Path);
+#endif
     }
 }
 #endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 
 ## [2.5.0]
 
+### Added
+
+- Added :gift_heart:: Support for Player Silencing in the AirConsole component. For more information visit the [AirConsole Player Silencing Guide](https://developers.airconsole.com/#!/guides/player_silencing).
+- Added :gift_heart:: Support for EMSDK_PYTHON when building for WebGL in Unity 2019 which requires python2 that needs to be manually installed on OSX Ventura / Sonoma! If your python2 is not in `/usr/local/bin/python2` you can update the path in the AirConsole Settings window.
+- Addition of version migration documentation for version migrations from 2.10 up to 2.5.0.
+
 ### Changed
+
 - StorePersistentData's uid parameter is no longer optional.
 - RequestPersistentData's uids parameter is no longer optional.
-- Addition of version migration documentation for version migrations from 2.10 and before.
 - Updated supported platforms list.
 
 ## [2.14] - 2022-11-02
@@ -23,7 +29,6 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 ### Fixed
 
 - Update Unity Webview to v1.0.1 to address WebGL builds
-
 
 ## [2.12] - 2023-10-10
 


### PR DESCRIPTION
Unity 2019 requires python2 as part of its build pipeline.
OSX Ventura removed that so users need to install it manually but python2 is no longer  directly accessible so we now set the EMSDK_PYTHON environment variable when building with Unity < 2020.