### PR TITLE
Implement version independent Android theme addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Thumbs.db
 # Visual Studio Code generated #
 # ============ #
 /.vs
+.utmp

--- a/Assets/AirConsole/scripts/editor/PreBuildProcessing.cs
+++ b/Assets/AirConsole/scripts/editor/PreBuildProcessing.cs
@@ -1,4 +1,6 @@
+#if !DISABLE_AIRCONSOLE
 #if UNITY_EDITOR
+using System;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -7,25 +9,22 @@ using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
 
-namespace NDream.AirConsole.Editor
-{
-    public class PreBuildProcessing : IPreprocessBuildWithReport
-    {
+namespace NDream.AirConsole.Editor {
+    public class PreBuildProcessing : IPreprocessBuildWithReport {
         public int callbackOrder => 1;
 
         private const string ANDROID_MANIFEST_PATH = "Assets/Plugins/Android/AndroidManifest.xml";
 
         private const string UNITY6_ANDROID_ACTIVITY_NAME = "com.unity3d.player.UnityPlayerGameActivity";
-        private const string UNITY_ANDROID_ACTIVITY_NAME = "com.unity3d.player.UnityPlayerActivity";
-
         private const string UNITY6_ANDROID_ACTIVITY_THEME = "@style/BaseUnityGameActivityTheme";
+        private const string UNITY_ANDROID_ACTIVITY_NAME = "com.unity3d.player.UnityPlayerActivity";
+        private const string UNITY_ANDROID_ACTIVITY_THEME = "@style/UnityThemeSelector";
 
 
-        public void OnPreprocessBuild(BuildReport report)
-        {
+        public void OnPreprocessBuild(BuildReport report) {
             CheckWebGLSetup();
 
-            Debug.Log("Used Python path: " + System.Environment.GetEnvironmentVariable("EMSDK_PYTHON"));
+            Debug.Log("Used Python path: " + Environment.GetEnvironmentVariable("EMSDK_PYTHON"));
 
             // In case you get a Build exception from Unity such as:
             //   System.ComponentModel.Win32Exception (2): No such file or directory)
@@ -44,88 +43,78 @@ namespace NDream.AirConsole.Editor
         }
 
 
-        private static void ValidateAndroidManifest()
-        {
+        private static void ValidateAndroidManifest() {
             string disabledManifestPath = Path.GetFullPath($"{ANDROID_MANIFEST_PATH}.DISABLED");
             string manifestPath = Path.GetFullPath(ANDROID_MANIFEST_PATH);
 
-            if (File.Exists(disabledManifestPath))
-            {
+            if (File.Exists(disabledManifestPath)) {
                 File.Move(disabledManifestPath, manifestPath);
             }
 
-            if (File.Exists(manifestPath))
-            {
+            if (File.Exists(manifestPath)) {
                 XDocument manifest = XDocument.Load(manifestPath);
 
-                if (manifest.Root == null) return;
+                if (manifest.Root == null) {
+                    return;
+                }
 
                 XElement[] applicationElements = manifest.Root.Elements("application").ToArray();
-                if (!applicationElements.Any()) return;
+                if (!applicationElements.Any()) {
+                    return;
+                }
 
                 XElement[] activityElements = applicationElements.Elements("activity").ToArray();
-                if (!activityElements.Any()) return;
+                if (!activityElements.Any()) {
+                    return;
+                }
 
                 XName nameAttribute = XName.Get("name", "http://schemas.android.com/apk/res/android");
                 XName themeAttribute = XName.Get("theme", "http://schemas.android.com/apk/res/android");
 
-                foreach (XElement activityElement in activityElements)
-                {
+                foreach (XElement activityElement in activityElements) {
                     XAttribute name = activityElement.Attribute(nameAttribute);
-                    if (name == null)
+                    if (name == null) {
                         continue;
+                    }
 
                     string activityName = name.Value;
-
-                    if (activityName == UNITY6_ANDROID_ACTIVITY_NAME || activityName == UNITY_ANDROID_ACTIVITY_NAME)
-                    {
-#if UNITY_6000_0_OR_NEWER
-                        name.Value = UNITY6_ANDROID_ACTIVITY_NAME;
-
+                    if (activityName == UNITY6_ANDROID_ACTIVITY_NAME) {
                         XAttribute theme = activityElement.Attribute(themeAttribute);
-                        if (theme == null)
-                        {
+                        if (theme == null) {
                             activityElement.SetAttributeValue(themeAttribute, UNITY6_ANDROID_ACTIVITY_THEME);
                         }
-#else
-                    name.Value = UNITY_ANDROID_ACTIVITY_NAME;
-#endif
-
-                        break;
+                    } else if (activityName == UNITY_ANDROID_ACTIVITY_NAME) {
+                        XAttribute theme = activityElement.Attribute(themeAttribute);
+                        if (theme == null) {
+                            activityElement.SetAttributeValue(themeAttribute, UNITY_ANDROID_ACTIVITY_THEME);
+                        }
                     }
                 }
 
                 manifest.Save(manifestPath);
-            }
-            else
-            {
+            } else {
                 throw new UnityException(
                     $"{ANDROID_MANIFEST_PATH} does not exist. AirConsole for Android TV requires specific settings. Please reimport the AirConsole package to recreate the correct AndroidManifest.");
             }
         }
 
-        private static void CheckWebGLSetup()
-        {
+        private static void CheckWebGLSetup() {
 #if UNITY_WEBGL
-            if (string.IsNullOrEmpty(PlayerSettings.WebGL.template))
-            {
+            if (string.IsNullOrEmpty(PlayerSettings.WebGL.template)) {
                 EditorUtility.DisplayDialog("Error", "No WebGL Template configured", "Cancel");
                 throw new UnityException("WebGL template not configured");
             }
 
-            if (Directory.Exists(GetWebGLTemplateDirectory()))
-            {
+            if (Directory.Exists(GetWebGLTemplateDirectory())) {
                 string templatePath = GetWebGLTemplateDirectory();
-                if (!Directory.GetFiles(templatePath).Any(filename => filename.EndsWith("controller.html")))
-                {
+                if (!Directory.GetFiles(templatePath).Any(filename => filename.EndsWith("controller.html"))) {
                     EditorUtility.DisplayDialog("Error",
                         "The controller has not yet been generated. Please execute the game at least once in play mode.",
                         "Cancel");
                     throw new UnityException("Controller missing in WebGL template location.");
                 }
 
-                if (!Directory.GetFiles(templatePath).Any(filename => filename.EndsWith("airconsole-unity-plugin.js")))
-                {
+                if (!Directory.GetFiles(templatePath).Any(filename => filename.EndsWith("airconsole-unity-plugin.js"))) {
                     EditorUtility.DisplayDialog("Error",
                         "airconsole-unity-plugin missing. Please set up your airconsole plugin again",
                         "Cancel");
@@ -135,10 +124,10 @@ namespace NDream.AirConsole.Editor
 #endif
         }
 
-        private static string GetWebGLTemplateDirectory()
-        {
+        private static string GetWebGLTemplateDirectory() {
             return Path.GetFullPath("Assets/WebGLTemplates/" + PlayerSettings.WebGL.template.Split(':')[1]);
         }
     }
 }
+#endif
 #endif


### PR DESCRIPTION
In Unity Plugin 2.5.6, when trying to build with Unity 6 and the Android Application Entry point set to 'Activity' instead of GameActivity, the build for Android will fail.

In general the logic seems to be too complicated for something that procedurally needs to add an XML attribute if absent.

This fix is independent of Android Native efforts and hence meant to be merged into `master`