### PR TITLE
Automatic Android Version code setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ Thumbs.db
 # Visual Studio Code generated #
 # ============ #
 /.vs
+TestBuilds/
 .utmp

--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -146,6 +146,8 @@ namespace NDream.AirConsole.Editor {
             UpdateAndroidPlayerSettingsInProperties();
             EnsureAndroidPlatformSettings();
             DisableUndesirableAndroidFeatures();
+
+            PlayerSettings.Android.bundleVersionCode = SecondsSinceStartOf2025();
         }
 
         private static void EnsureAndroidPlatformSettings() {
@@ -239,6 +241,13 @@ namespace NDream.AirConsole.Editor {
                                  + "Updating the Android Graphics APIs now.");
                 PlayerSettings.SetGraphicsAPIs(BuildTarget.Android, graphicsAPIs);
             }
+        }
+        
+        private static int SecondsSinceStartOf2025() {
+            DateTime startOfYear = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime now = DateTime.UtcNow; 
+
+            return (int)(now - startOfYear).TotalSeconds;
         }
 
         [MenuItem("Tools/AirConsole/Check Android Config")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Added
+
+- Automatically set androidVersionCode to `seconds since 2025-01-01T00:00:00` to ensure conflict free builds.
 
 ## [2.5.6] - 2025-02-11
 
 This release fixes an issue where the Unity loader is causing requests to non-existing files in Unity 6 web builds.
-
 
 ## [2.5.5] - 2025-01-07
 
@@ -19,7 +21,6 @@ This release patches a bug introduced in version 2.5.4
 ### Fixed
 
 - We fixed the AirConsole settings to use the correct Unity WebGL template with Unity versions before Unity 6 and after Unity 2020.1.
-
 
 ## [2.5.4] - 2024-12-10
 


### PR DESCRIPTION
Given that the Version Code needs to continuous rise for even reuploads to work on certain Android stores, I would like to propose that we automatically set the Android VersionCode to 'seconds since 2025-01-01T00:00:00' which ensures that it monotonously increases.