### PR TITLE
Fix etc2 astc ensurance

### DIFF
--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -256,7 +256,7 @@ namespace NDream.AirConsole.Editor {
         private static bool IsDesirableTextureCompressionFormat(BuildTargetGroup targetGroup) {
             TextureCompressionFormat format = GetDefaultTextureCompressionFormat(targetGroup);
             return format is TextureCompressionFormat.ASTC or TextureCompressionFormat.ETC2
-                   && (targetGroup == BuildTargetGroup.Android
+                   || (targetGroup == BuildTargetGroup.Android
                        ? EditorUserBuildSettings.androidBuildSubtarget is MobileTextureSubtarget.ASTC or MobileTextureSubtarget.ETC2
                        : EditorUserBuildSettings.webGLBuildSubtarget is WebGLTextureSubtarget.ASTC or WebGLTextureSubtarget.ETC2);
         }


### PR DESCRIPTION
This improves the logic to ensure that either the Build Settings or the
Player Settings of the respective platform are set to ETC2 or ASTC.
The logic also works with Unity 6 where Android Texture formats are a
list, not a single dropdown.