### PR TITLE
Add module validation

### DIFF
--- a/Assets/AirConsole/scripts/Settings.cs
+++ b/Assets/AirConsole/scripts/Settings.cs
@@ -21,21 +21,13 @@ namespace NDream.AirConsole {
 
         public static readonly string WEBTEMPLATE_PATH;
 
-        private const string TEMPLATE_NAME = "AirConsole";
         private const string TEMPLATE_NAME_2020 = "AirConsole-2020";
         private const string TEMPLATE_NAME_U6 = "AirConsole-U6";
 
-        public static readonly string[] TEMPLATE_NAMES = { TEMPLATE_NAME, TEMPLATE_NAME_2020, TEMPLATE_NAME_U6 };
+        public static readonly string[] TEMPLATE_NAMES = { TEMPLATE_NAME_2020, TEMPLATE_NAME_U6 };
 
         static Settings() {
-            string templateName;
-#if UNITY_6000_0_OR_NEWER
-            templateName = TEMPLATE_NAME_U6;
-#elif !UNITY_2020_1_OR_NEWER
-            templateName = TEMPLATE_NAME;
-#else
-            templateName = TEMPLATE_NAME_2020;
-#endif
+            string templateName = IsUnity6OrHigher() ? TEMPLATE_NAME_U6 : TEMPLATE_NAME_2020;
             WEBTEMPLATE_PATH = $"/WebGLTemplates/{templateName}";
         }
 

--- a/Assets/AirConsole/scripts/Settings.cs
+++ b/Assets/AirConsole/scripts/Settings.cs
@@ -39,9 +39,9 @@ namespace NDream.AirConsole {
             WEBTEMPLATE_PATH = $"/WebGLTemplates/{templateName}";
         }
 
-        public static bool IsUnity6OrHigher() {
-            return int.Parse(Application.unityVersion.Split('.')[0]) >= 6000;
-        }
+        public static bool IsUnity6OrHigher() => int.Parse(Application.unityVersion.Split('.')[0]) >= 6000;
+
+        public static bool IsUnity2022OrHigher() => int.Parse(Application.unityVersion.Split('.')[0]) >= 2022;
     }
 }
 #endif

--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -123,7 +123,7 @@ namespace NDream.AirConsole.Editor {
         [InitializeOnLoadMethod]
         private static void EnsureWebGLPlayerSettings() {
             VerifyWebGLTemplate();
-            
+
             PlayerSettings.WebGL.linkerTarget = WebGLLinkerTarget.Wasm;
             PlayerSettings.WebGL.nameFilesAsHashes = false; // We upload into timestamp based folders. This is not necessary.
 
@@ -288,7 +288,7 @@ namespace NDream.AirConsole.Editor {
         }
 
         private static int SecondsSinceStartOf2025() {
-            DateTime startOfYear = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime startOfYear = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             DateTime now = DateTime.UtcNow;
 
             return (int)(now - startOfYear).TotalSeconds;

--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -280,10 +280,10 @@ namespace NDream.AirConsole.Editor {
                 PlayerSettings.SetGraphicsAPIs(BuildTarget.Android, graphicsAPIs);
             }
         }
-        
+
         private static int SecondsSinceStartOf2025() {
             DateTime startOfYear = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            DateTime now = DateTime.UtcNow; 
+            DateTime now = DateTime.UtcNow;
 
             return (int)(now - startOfYear).TotalSeconds;
         }

--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -16,6 +16,7 @@ namespace NDream.AirConsole.Editor {
                 message +=
                     "\nTo disable AirConsole for this build, add the scripting define symbol 'DISABLE_AIRCONSOLE' in the Player Settings.";
             }
+
             Debug.LogError(message);
             throw new UnityException(message);
         }
@@ -58,8 +59,12 @@ namespace NDream.AirConsole.Editor {
             Type moduleManager = Type.GetType("UnityEditor.Modules.ModuleManager,UnityEditor.dll");
             MethodInfo IsPlatformSupportLoadedByBuildTarget = moduleManager.GetMethod("IsPlatformSupportLoadedByBuildTarget",
                 BindingFlags.Static | BindingFlags.NonPublic);
-            bool result = (bool)IsPlatformSupportLoadedByBuildTarget.Invoke(null, new object[] { buildTarget });
-            return result;
+
+            if (IsPlatformSupportLoadedByBuildTarget != null) {
+                return (bool)IsPlatformSupportLoadedByBuildTarget.Invoke(null, new object[] { buildTarget });
+            }
+
+            return true;
         }
     }
 

--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -161,7 +161,8 @@ namespace NDream.AirConsole.Editor {
 
                 if (EditorUtility.DisplayDialog("Incompatible WebGL Template", incompatibleTemplateMessage, "Open Player Settings",
                         "Cancel")) {
-                    SettingsService.OpenProjectSettings("Project/Player");
+                    // In Unity 6 this needs to be done with a delay call, otherwise it breaks the window layout when Project Settings are docked already.
+                    EditorApplication.delayCall = () => SettingsService.OpenProjectSettings("Project/Player"); 
                 }
             }
         }

--- a/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
+++ b/Assets/AirConsole/scripts/editor/ProjectConfigurationCheck.cs
@@ -101,8 +101,9 @@ namespace NDream.AirConsole.Editor {
             PlayerSettings.resetResolutionOnWindowResize = true;
 
             if (!UnityVersionCheck.IsSupportedUnityVersion()) {
-                Debug.LogError("AirConsole Unity Plugin 2.6.0 and above require Unity 2022.3 LTS or newer");
-                throw new UnityException("Unity Version " + Application.unityVersion);
+                string message = $"AirConsole {Settings.VERSION} requires Unity 2022.3 or newer. You are using {Application.unityVersion}.";
+                Debug.LogError(message);
+                throw new UnityException(message);
             }
 
             bool shouldRunInBackground = EditorUserBuildSettings.activeBuildTarget == BuildTarget.WebGL;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 
 - Automatically set androidVersionCode to `seconds since 2025-01-01T00:00:00` to ensure conflict free builds.
 - We now automatically update the AndroidManifest as necessary for AirConsole to work on Android. We also remove old settings that are no longer necessary or conflict with Unity 2022 or Unity 6.
+- AirConsole validates that at least one of the required Unity Platform modules (WebGL or Android) is installed when projects are opened on other platforms without the DISABLE_AIRCONSOLE script predefine being set.
 
 ### Removed
 


### PR DESCRIPTION
Unity does not provide API to check if a platform is present before
switching platforms. It only fails if not present.

To overcome this we use reflection to call Unity's internal API from the
ModuleManager to query the module presence state
(IsPlatformSupportLoaded - we do it ByBuildTarget for typing reasons)
before doing the platform switch or to inform the developer that no
supported module is found and that AirConsole can not be used.

This PR also brings back the WebGL Template check that went missing on release/2.6.0, commit e38754f6f11371fc8ca5f96c8fc8b33d752eb3b8 and fixes a bug that breaks the editor rendering in Unity 6 if Project Settings are docked already.