### PR TITLE
Implement AirConsole Logger

### DIFF
--- a/Assets/AirConsole/scripts/AirConsoleLogger.cs
+++ b/Assets/AirConsole/scripts/AirConsoleLogger.cs
@@ -1,0 +1,24 @@
+#if !DISABLE_AIRCONSOLE
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace NDream.AirConsole {
+    public class AirConsoleLogger {
+        [System.Diagnostics.Conditional("AIRCONSOLE_DEVELOPMENT")]
+        public static void LogDevelopment(string message) => Debug.Log($"AC UNITY DEVELOPMENT: {message}");
+
+        [System.Diagnostics.Conditional("AIRCONSOLE_DEVELOPMENT")]
+        public static void LogDevelopment(string message, Object context) => Debug.Log($"AC UNITY DEVELOPMENT: {message}", context);
+
+        public static void Log(string message) => Debug.Log(message);
+        public static void Log(string message, Object context) => Debug.Log(message, context);
+        public static void LogWarning(string message) => Debug.LogWarning(message);
+        public static void LogWarning(string message, Object context) => Debug.LogWarning(message, context);
+        public static void LogError(string message) => Debug.LogError(message);
+        public static void LogError(string message, Object context) => Debug.LogError(message, context);
+        public static void LogException(Exception exception) => Debug.LogException(exception);
+        public static void LogException(Exception exception, Object context) => Debug.LogException(exception, context);
+    }
+}
+#endif

--- a/Assets/AirConsole/scripts/AirConsoleLogger.cs.meta
+++ b/Assets/AirConsole/scripts/AirConsoleLogger.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b6b58d993a7f48da95496caa6d642f28
+timeCreated: 1728905162


### PR DESCRIPTION
AirConsoleLogger wraps the regular Unity Debug logging with additional LogDevelopment that are dependent on an AIRCONSOLE_DEVELOPMENT script define so we can enable it while developing technology without impacting the runtime of game developers or our own test builds.