### PR TITLE
Remove Python SDK handling

### DIFF
--- a/Assets/AirConsole/scripts/AirConsole.cs
+++ b/Assets/AirConsole/scripts/AirConsole.cs
@@ -1196,7 +1196,7 @@ namespace NDream.AirConsole {
 
         public static T ACFindObjectOfType<T>() where T : UnityEngine.Object {
 #if !UNITY_6000_0_OR_NEWER
-            return UnityEngine.Object.FindObjectOfType<T>();
+            return FindObjectOfType<T>();
 #else
             return FindFirstObjectByType<T>();
 #endif

--- a/Assets/AirConsole/scripts/Settings.cs
+++ b/Assets/AirConsole/scripts/Settings.cs
@@ -17,8 +17,6 @@ namespace NDream.AirConsole {
         public static int webServerPort = 7842;
         public static int webSocketPort = 7843;
         public static DebugLevel debug = new();
-        public static string Python2Path = "/usr/local/bin/python2";
-
         public static readonly string WEBTEMPLATE_PATH;
 
         private const string TEMPLATE_NAME = "AirConsole";

--- a/Assets/AirConsole/scripts/editor/Extentions.cs
+++ b/Assets/AirConsole/scripts/editor/Extentions.cs
@@ -73,10 +73,6 @@ namespace NDream.AirConsole.Editor {
 			if (EditorPrefs.GetBool ("debugError", true) != true) {
 				Settings.debug.error = EditorPrefs.GetBool ("debugError");
 			}
-
-			if (EditorPrefs.GetString("python2Path", "") != "") {
-				Settings.Python2Path = EditorPrefs.GetString("python2Path");
-			}
 		}
 
 		public static void ResetDefaultValues () {

--- a/Assets/AirConsole/scripts/editor/Extentions.cs
+++ b/Assets/AirConsole/scripts/editor/Extentions.cs
@@ -60,10 +60,10 @@ namespace NDream.AirConsole.Editor {
                 Settings.debug.warning = EditorPrefs.GetBool("debugWarning");
             }
 
-			if (EditorPrefs.GetBool ("debugError", true) != true) {
-				Settings.debug.error = EditorPrefs.GetBool ("debugError");
-			}
-		}
+            if (EditorPrefs.GetBool("debugError", true) != true) {
+                Settings.debug.error = EditorPrefs.GetBool("debugError");
+            }
+        }
 
         public static void ResetDefaultValues() {
             Settings.debug.info = DebugLevel.DEFAULT_INFO;

--- a/Assets/AirConsole/scripts/editor/PreBuildProcessing.cs
+++ b/Assets/AirConsole/scripts/editor/PreBuildProcessing.cs
@@ -1,9 +1,7 @@
 #if !DISABLE_AIRCONSOLE
 #if UNITY_EDITOR
-using System;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
@@ -13,27 +11,12 @@ namespace NDream.AirConsole.Editor {
     public class PreBuildProcessing : IPreprocessBuildWithReport {
         public int callbackOrder => 1;
 
-        public void OnPreprocessBuild(BuildReport report)
-        {
+        public void OnPreprocessBuild(BuildReport report) {
             CheckWebGLSetup();
-
-            Debug.Log("Used Python path: " + Environment.GetEnvironmentVariable("EMSDK_PYTHON"));
-
-            // In case you get a Build exception from Unity such as:
-            //   System.ComponentModel.Win32Exception (2): No such file or directory)
-            // Make sure that the correct Python version is installed and can be found by Unity during
-            // the Build process.
-
-            // If you need to set the Python path manually you can use the code below, uncomment it and
-            // set "EMSDK_PYTHON" to the the Python 3 (Or Python 2 for old Unity versions) path:
-#if !UNITY_2020_1_OR_NEWER && UNITY_EDITOR_OSX
-        System.Environment.SetEnvironmentVariable("EMSDK_PYTHON", Settings.Python2Path);
-#endif
-
         }
 
         private static void CheckWebGLSetup() {
-#if UNITY_WEBGL
+#if UNITY_WEBGL 
             if (string.IsNullOrEmpty(PlayerSettings.WebGL.template)) {
                 EditorUtility.DisplayDialog("Error", "No WebGL Template configured", "Cancel");
                 throw new UnityException("WebGL template not configured");

--- a/Assets/AirConsole/scripts/editor/SettingWindow.cs
+++ b/Assets/AirConsole/scripts/editor/SettingWindow.cs
@@ -80,12 +80,6 @@ namespace NDream.AirConsole.Editor {
 
 			EditorGUILayout.EndToggleGroup ();
 
-
-			EditorGUILayout.BeginHorizontal();
-			Settings.Python2Path = EditorGUILayout.TextField("Python 2 Path", Settings.Python2Path, GUILayout.MinWidth(600));
-			EditorPrefs.SetString("python2Path", Settings.Python2Path);
-			GUILayout.EndHorizontal();
-
 			EditorGUILayout.BeginHorizontal (styleBlack);
 
 			GUILayout.FlexibleSpace ();

--- a/Assets/AirConsole/scripts/editor/SettingWindow.cs
+++ b/Assets/AirConsole/scripts/editor/SettingWindow.cs
@@ -77,7 +77,7 @@ namespace NDream.AirConsole.Editor {
 
             EditorGUILayout.EndToggleGroup();
 
-			EditorGUILayout.BeginHorizontal (styleBlack);
+            EditorGUILayout.BeginHorizontal(styleBlack);
 
             GUILayout.FlexibleSpace();
             if (GUILayout.Button("Reset Settings", GUILayout.MaxWidth(110))) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 ### Removed
 
 - AndroidManifest: The plugin no longer ships with a custom AndroidManifest.
+- Python SDK handling has been removed. This feature was only required for Unity 2019 on MacOS 12+
 
 ## [2.5.6] - 2025-02-11
 


### PR DESCRIPTION
This feature was originally required for Unity 2019 on OSX where python2 was removed with an OSX update.

Duplicate of the approved https://github.com/AirConsole/airconsole-unity-plugin/pull/91 that was pointing at the wrong branch.