### PR TITLE
Refactor weblistener

### DIFF
--- a/Assets/AirConsole/scripts/Runtime/WebsocketListener.cs
+++ b/Assets/AirConsole/scripts/Runtime/WebsocketListener.cs
@@ -88,7 +88,7 @@ namespace NDream.AirConsole {
             this.webViewObject = webViewObject;
         }
 #else
-        public WebsocketListener() {
+        public WebsocketListener () {
             IgnoreExtensions = true;
         }
 #endif
@@ -111,9 +111,7 @@ namespace NDream.AirConsole {
         protected override void OnClose(CloseEventArgs e) {
             isReady = false;
 
-            if (onClose != null) {
-                onClose();
-            }
+            onClose?.Invoke();
 
             if (Settings.debug.info) {
                 Debug.Log("AirConsole: screen.html disconnected");
@@ -133,95 +131,78 @@ namespace NDream.AirConsole {
 
         public void ProcessMessage(string data) {
             try {
-                // parse json string
                 JObject msg = JObject.Parse(data);
+                string action = msg.SelectToken("action")?.Value<string>();
 
-                if ((string)msg["action"] == "onReady") {
-                    isReady = true;
+                switch (action) {
+                    case "onReady": {
+                        isReady = true;
 
-                    if (onReady != null) {
-                        onReady(msg);
-                    }
+                        onReady?.Invoke(msg);
 
-                    if (Settings.debug.info) {
-                        Debug.Log("AirConsole: Connections are ready!");
+                        if (Settings.debug.info) {
+                            Debug.Log("AirConsole: Connections are ready!");
+                        }
+
+                        break;
                     }
-                } else if ((string)msg["action"] == "onMessage") {
-                    if (onMessage != null) {
-                        onMessage(msg);
-                    }
-                } else if ((string)msg["action"] == "onDeviceStateChange") {
-                    if (onDeviceStateChange != null) {
-                        onDeviceStateChange(msg);
-                    }
-                } else if ((string)msg["action"] == "onConnect") {
-                    if (onConnect != null) {
-                        onConnect(msg);
-                    }
-                } else if ((string)msg["action"] == "onDisconnect") {
-                    if (onDisconnect != null) {
-                        onDisconnect(msg);
-                    }
-                } else if ((string)msg["action"] == "onCustomDeviceStateChange") {
-                    if (onCustomDeviceStateChange != null) {
-                        onCustomDeviceStateChange(msg);
-                    }
-                } else if ((string)msg["action"] == "onDeviceProfileChange") {
-                    if (onDeviceProfileChange != null) {
-                        onDeviceProfileChange(msg);
-                    }
-                } else if ((string)msg["action"] == "onAdShow") {
-                    if (onAdShow != null) {
-                        onAdShow(msg);
-                    }
-                } else if ((string)msg["action"] == "onAdComplete") {
-                    if (onAdComplete != null) {
-                        onAdComplete(msg);
-                    }
-                } else if ((string)msg["action"] == "onGameEnd") {
-                    if (onGameEnd != null) {
-                        onGameEnd(msg);
-                    }
-                } else if ((string)msg["action"] == "onHighScores") {
-                    if (onHighScores != null) {
-                        onHighScores(msg);
-                    }
-                } else if ((string)msg["action"] == "onHighScoreStored") {
-                    if (onHighScoreStored != null) {
-                        onHighScoreStored(msg);
-                    }
-                } else if ((string)msg["action"] == "onPersistentDataStored") {
-                    if (onPersistentDataStored != null) {
-                        onPersistentDataStored(msg);
-                    }
-                } else if ((string)msg["action"] == "onPersistentDataLoaded") {
-                    if (onPersistentDataLoaded != null) {
-                        onPersistentDataLoaded(msg);
-                    }
-                } else if ((string)msg["action"] == "onPremium") {
-                    if (onPremium != null) {
-                        onPremium(msg);
-                    }
-                } else if ((string)msg["action"] == "onPause") {
-                    if (onPause != null) {
-                        onPause(msg);
-                    }
-                } else if ((string)msg["action"] == "onResume") {
-                    if (onResume != null) {
-                        onResume(msg);
-                    }
-                } else if ((string)msg["action"] == "onLaunchApp") {
-                    if (onLaunchApp != null) {
-                        onLaunchApp(msg);
-                    }
-                } else if ((string)msg["action"] == "onUnityWebviewResize") {
-                    if (onUnityWebviewResize != null) {
-                        onUnityWebviewResize(msg);
-                    }
-                } else if ((string)msg["action"] == "onUnityWebviewPlatformReady") {
-                    if (onUnityWebviewPlatformReady != null) {
-                        onUnityWebviewPlatformReady(msg);
-                    }
+                    case "onMessage":
+                        onMessage?.Invoke(msg);
+                        break;
+                    case "onDeviceStateChange":
+                        onDeviceStateChange?.Invoke(msg);
+                        break;
+                    case "onConnect":
+                        onConnect?.Invoke(msg);
+                        break;
+                    case "onDisconnect":
+                        onDisconnect?.Invoke(msg);
+                        break;
+                    case "onCustomDeviceStateChange":
+                        onCustomDeviceStateChange?.Invoke(msg);
+                        break;
+                    case "onDeviceProfileChange":
+                        onDeviceProfileChange?.Invoke(msg);
+                        break;
+                    case "onAdShow":
+                        onAdShow?.Invoke(msg);
+                        break;
+                    case "onAdComplete":
+                        onAdComplete?.Invoke(msg);
+                        break;
+                    case "onGameEnd":
+                        onGameEnd?.Invoke(msg);
+                        break;
+                    case "onHighScores":
+                        onHighScores?.Invoke(msg);
+                        break;
+                    case "onHighScoreStored":
+                        onHighScoreStored?.Invoke(msg);
+                        break;
+                    case "onPersistentDataStored":
+                        onPersistentDataStored?.Invoke(msg);
+                        break;
+                    case "onPersistentDataLoaded":
+                        onPersistentDataLoaded?.Invoke(msg);
+                        break;
+                    case "onPremium":
+                        onPremium?.Invoke(msg);
+                        break;
+                    case "onPause":
+                        onPause?.Invoke(msg);
+                        break;
+                    case "onResume":
+                        onResume?.Invoke(msg);
+                        break;
+                    case "onLaunchApp":
+                        onLaunchApp?.Invoke(msg);
+                        break;
+                    case "onUnityWebviewResize":
+                        onUnityWebviewResize?.Invoke(msg);
+                        break;
+                    case "onUnityWebviewPlatformReady":
+                        onUnityWebviewPlatformReady?.Invoke(msg);
+                        break;
                 }
             } catch (Exception e) {
                 if (Settings.debug.error) {
@@ -236,15 +217,20 @@ namespace NDream.AirConsole {
         }
 
         public void Message(JObject data) {
-            if (Application.platform == RuntimePlatform.WebGLPlayer) {
-                Application.ExternalCall("window.app.processUnityData", data.ToString()); //TODO: External Call is obsolete?
-            } else if (Application.platform == RuntimePlatform.Android) {
+            switch (Application.platform) {
+                case RuntimePlatform.WebGLPlayer:
+                    Application.ExternalCall("window.app.processUnityData", data.ToString()); //TODO: External Call is obsolete?
+                    break;
+                case RuntimePlatform.Android: {
 #if UNITY_ANDROID
-                string serialized = JsonConvert.ToString(data.ToString());
-                webViewObject.EvaluateJS("androidUnityPostMessage(" + serialized + ");");
+                    string serialized = JsonConvert.ToString(data.ToString());
+                    webViewObject.EvaluateJS("androidUnityPostMessage(" + serialized + ");");
 #endif
-            } else {
-                Send(data.ToString());
+                    break;
+                }
+                default:
+                    Send(data.ToString());
+                    break;
             }
         }
     }

--- a/Assets/AirConsole/scripts/Runtime/WebsocketListener.cs
+++ b/Assets/AirConsole/scripts/Runtime/WebsocketListener.cs
@@ -1,84 +1,36 @@
 ﻿#if !DISABLE_AIRCONSOLE
 using UnityEngine;
-using System.Collections;
-using System.Collections.Generic;
-using System.Runtime.Serialization.Formatters;
 using System;
+using Newtonsoft.Json;
 using WebSocketSharp;
 using WebSocketSharp.Server;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace NDream.AirConsole {
-    // event delegates
-    public delegate void OnReadyInternal(JObject data);
-
-    public delegate void OnMessageInternal(JObject data);
-
-    public delegate void OnDeviceStateChangeInternal(JObject data);
-
-    public delegate void OnConnectInternal(JObject data);
-
-    public delegate void OnDisconnectInternal(JObject data);
-
-    public delegate void OnCustomDeviceStateChangeInternal(JObject data);
-
-    public delegate void OnDeviceProfileChangeInternal(JObject data);
-
-    public delegate void OnAdShowInternal(JObject data);
-
-    public delegate void OnAdCompleteInternal(JObject data);
-
-    public delegate void OnGameEndInternal(JObject data);
-
-    public delegate void OnHighScoresInternal(JObject data);
-
-    public delegate void OnHighScoreStoredInternal(JObject data);
-
-    public delegate void OnPersistentDataStoredInternal(JObject data);
-
-    public delegate void OnPersistentDataLoadedInternal(JObject data);
-
-    public delegate void OnPremiumInternal(JObject data);
-
-    public delegate void OnPauseInternal(JObject data);
-
-    public delegate void OnResumeInternal(JObject data);
-
-    public delegate void OnLaunchAppInternal(JObject data);
-
-    public delegate void OnUnityWebviewResizeInternal(JObject data);
-
-    public delegate void OnUnityWebviewPlatformReadyInternal(JObject data);
-
-    public delegate void OnCloseInternal();
-
     public class WebsocketListener : WebSocketBehavior {
-        // events
-        public event OnReadyInternal onReady;
-        public event OnCloseInternal onClose;
-        public event OnMessageInternal onMessage;
-        public event OnDeviceStateChangeInternal onDeviceStateChange;
-        public event OnConnectInternal onConnect;
-        public event OnDisconnectInternal onDisconnect;
-        public event OnCustomDeviceStateChangeInternal onCustomDeviceStateChange;
-        public event OnDeviceProfileChangeInternal onDeviceProfileChange;
-        public event OnAdShowInternal onAdShow;
-        public event OnAdCompleteInternal onAdComplete;
-        public event OnGameEndInternal onGameEnd;
-        public event OnHighScoresInternal onHighScores;
-        public event OnHighScoreStoredInternal onHighScoreStored;
-        public event OnPersistentDataStoredInternal onPersistentDataStored;
-        public event OnPersistentDataLoadedInternal onPersistentDataLoaded;
-        public event OnPremiumInternal onPremium;
-        public event OnPauseInternal onPause;
-        public event OnResumeInternal onResume;
-        public event OnLaunchAppInternal onLaunchApp;
-        public event OnUnityWebviewResizeInternal onUnityWebviewResize;
-        public event OnUnityWebviewPlatformReadyInternal onUnityWebviewPlatformReady;
+        public event Action<JObject> onReady;
+        public event Action onClose;
+        public event Action<JObject> onMessage;
+        public event Action<JObject> onDeviceStateChange;
+        public event Action<JObject> onConnect;
+        public event Action<JObject> onDisconnect;
+        public event Action<JObject> onCustomDeviceStateChange;
+        public event Action<JObject> onDeviceProfileChange;
+        public event Action<JObject> onAdShow;
+        public event Action<JObject> onAdComplete;
+        public event Action<JObject> onGameEnd;
+        public event Action<JObject> onHighScores;
+        public event Action<JObject> onHighScoreStored;
+        public event Action<JObject> onPersistentDataStored;
+        public event Action<JObject> onPersistentDataLoaded;
+        public event Action<JObject> onPremium;
+        public event Action<JObject> onPause;
+        public event Action<JObject> onResume;
+        public event Action<JObject> onLaunchApp;
+        public event Action<JObject> onUnityWebviewResize;
+        public event Action<JObject> onUnityWebviewPlatformReady;
 
-        // private vars
-        private bool isReady;
+        private bool _isReady;
 
 #if UNITY_ANDROID
         private WebViewObject webViewObject;
@@ -88,7 +40,7 @@ namespace NDream.AirConsole {
             this.webViewObject = webViewObject;
         }
 #else
-        public WebsocketListener () {
+        public WebsocketListener() {
             IgnoreExtensions = true;
         }
 #endif
@@ -109,7 +61,7 @@ namespace NDream.AirConsole {
         }
 
         protected override void OnClose(CloseEventArgs e) {
-            isReady = false;
+            _isReady = false;
 
             onClose?.Invoke();
 
@@ -136,7 +88,7 @@ namespace NDream.AirConsole {
 
                 switch (action) {
                     case "onReady": {
-                        isReady = true;
+                        _isReady = true;
 
                         onReady?.Invoke(msg);
 
@@ -212,9 +164,7 @@ namespace NDream.AirConsole {
             }
         }
 
-        public bool IsReady() {
-            return isReady;
-        }
+        public bool IsReady() => _isReady;
 
         public void Message(JObject data) {
             switch (Application.platform) {


### PR DESCRIPTION
The idea behind the change from Delegate to Action is that for internal (instead of public API), we do not need this - it adds no value but additional abstraction and mental redirections.

For public APIs like the one on AirConsole I would retain and continue building on delegates for the self documenting benefit, even if many are the same.