### PR TITLE
Improve unity playmode network management

### DIFF
--- a/Assets/AirConsole/scripts/Editor/Extentions.cs
+++ b/Assets/AirConsole/scripts/Editor/Extentions.cs
@@ -12,11 +12,6 @@ namespace NDream.AirConsole.Editor {
 
         static Extentions() {
             InitSettings();
-
-            if (webserver != null) {
-                webserver.Start();
-            }
-
             PlayMode.PlayModeChanged += OnPlayModeStateChanged;
         }
 

--- a/Assets/AirConsole/scripts/Editor/SettingWindow.cs
+++ b/Assets/AirConsole/scripts/Editor/SettingWindow.cs
@@ -51,19 +51,6 @@ namespace NDream.AirConsole.Editor {
 
             EditorGUILayout.LabelField("Webserver is running", Extentions.webserver.IsRunning().ToString());
 
-            GUILayout.BeginHorizontal();
-
-            GUILayout.Space(150);
-            if (GUILayout.Button("Stop", GUILayout.MaxWidth(60))) {
-                Extentions.webserver.Stop();
-            }
-
-            if (GUILayout.Button("Restart", GUILayout.MaxWidth(60))) {
-                Extentions.webserver.Restart();
-            }
-
-            GUILayout.EndHorizontal();
-
             groupEnabled = EditorGUILayout.BeginToggleGroup("Debug Settings", groupEnabled);
 
             Settings.debug.info = EditorGUILayout.Toggle("Info", Settings.debug.info);

--- a/Assets/AirConsole/scripts/Editor/WebListener.cs
+++ b/Assets/AirConsole/scripts/Editor/WebListener.cs
@@ -20,13 +20,6 @@ namespace NDream.AirConsole.Editor {
             startUpPath = path;
         }
 
-        private void HandlePlaymodeStop(PlayModeStateChange change) {
-            if (change is PlayModeStateChange.ExitingEditMode or PlayModeStateChange.ExitingPlayMode) {
-                Stop();
-                EditorApplication.playModeStateChanged -= HandlePlaymodeStop;
-            }
-        }
-
         public void Start() {
             if (listener == null) {
                 listener = new HttpListener();
@@ -148,6 +141,13 @@ namespace NDream.AirConsole.Editor {
                     return "application/javascript";
                 default:
                     return "application/octet-stream";
+            }
+        }
+
+        private void HandlePlaymodeStop(PlayModeStateChange change) {
+            if (change is PlayModeStateChange.ExitingEditMode or PlayModeStateChange.ExitingPlayMode) {
+                Stop();
+                EditorApplication.playModeStateChanged -= HandlePlaymodeStop;
             }
         }
 

--- a/Assets/AirConsole/scripts/Editor/WebListener.cs
+++ b/Assets/AirConsole/scripts/Editor/WebListener.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Net;
 using System.IO;
 using System.Text;
+using UnityEditor;
 using UnityEngine;
 
 namespace NDream.AirConsole.Editor {
@@ -13,10 +14,17 @@ namespace NDream.AirConsole.Editor {
         private string startUpPath;
         private string prefix;
         private HttpListenerContext request;
-        private Thread t;
+        private Thread listenerThread;
 
         public void SetPath(string path) {
             startUpPath = path;
+        }
+
+        private void HandlePlaymodeStop(PlayModeStateChange change) {
+            if (change is PlayModeStateChange.ExitingEditMode or PlayModeStateChange.ExitingPlayMode) {
+                Stop();
+                EditorApplication.playModeStateChanged -= HandlePlaymodeStop;
+            }
         }
 
         public void Start() {
@@ -24,22 +32,25 @@ namespace NDream.AirConsole.Editor {
                 listener = new HttpListener();
             }
 
-            prefix = string.Format("http://*:{0}/", Settings.webServerPort.ToString());
-
-            if (!listener.IsListening) {
-                listener.Start();
-
-                if (!listener.Prefixes.Contains(prefix)) {
-                    listener.Prefixes.Add(prefix);
-                }
-
-                if (t != null && t.IsAlive) {
-                    t.Abort();
-                }
-
-                t = new Thread(new ThreadStart(ClientListener));
-                t.Start();
+            if (listener.IsListening) {
+                return;
             }
+
+            AirConsoleLogger.LogDevelopment("Starting WebListener");
+            EditorApplication.playModeStateChanged += HandlePlaymodeStop;
+            listener.Start();
+
+            prefix = $"http://*:{Settings.webServerPort}/";
+            if (!listener.Prefixes.Contains(prefix)) {
+                listener.Prefixes.Add(prefix);
+            }
+
+            if (listenerThread != null && listenerThread.IsAlive) {
+                listenerThread.Abort();
+            }
+
+            listenerThread = new Thread(ClientListener);
+            listenerThread.Start();
         }
 
         public bool IsRunning() {
@@ -140,14 +151,10 @@ namespace NDream.AirConsole.Editor {
             }
         }
 
-        public void Stop() {
-            t.Abort();
+        private void Stop() {
+            AirConsoleLogger.LogDevelopment("Stopping WebListener");
+            listenerThread.Abort();
             listener.Stop();
-        }
-
-        public void Restart() {
-            Stop();
-            Start();
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 - We now automatically update the AndroidManifest as necessary for AirConsole to work on Android. We also remove old settings that are no longer necessary or conflict with Unity 2022 or Unity 6.
 - AirConsole validates that at least one of the required Unity Platform modules (WebGL or Android) is installed when projects are opened on other platforms without the DISABLE_AIRCONSOLE script predefine being set.
 
+### Changed
+
+- AirConsole now opens the socket server during playmode and closes it again afterwards to avoid the need to restart the editor.
+
 ### Removed
 
 - AndroidManifest: The plugin no longer ships with a custom AndroidManifest.


### PR DESCRIPTION
This addresses the problem where sockets could get locked up until a reboot of Unity.

This builds upon #74, expanding it with Editor Playmode lifecycle detection to close the connection again.