### PR TITLE
marc-integrate-android-manifest-update

### DIFF
--- a/Assets/AirConsole/scripts/Editor/BuildAutomation/AndroidGradleProcessor.cs
+++ b/Assets/AirConsole/scripts/Editor/BuildAutomation/AndroidGradleProcessor.cs
@@ -1,27 +1,21 @@
-using UnityEngine;
 #if !DISABLE_AIRCONSOLE
 
 namespace NDream.AirConsole.Editor {
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using UnityEditor.Android;
 
-    public class AndroidGradleProcessor : IPostGenerateGradleAndroidProject {
+    internal abstract class AndroidGradleProcessor {
         private const string PROGUARD_CLASSMEMBERS = "-keepclasseswithmembers class com.airconsole.unityandroidlibrary.** {*;}";
 
-        public int callbackOrder {
-            get => 999;
-        }
-
-        public void OnPostGenerateGradleAndroidProject(string basePath) {
+        internal static void Execute(string basePath) {
             UpdateMainGradleProperties(Path.GetFullPath(Path.Combine(basePath, "..")), "gradle.properties");
             UpdateMainGradleTemplate(Path.GetFullPath(basePath), "build.gradle");
             UpdateProGuard(Path.GetFullPath(basePath), "proguard-unity.txt");
             AirConsoleLogger.LogDevelopment("Updated gradle files for AirConsole Android build");
         }
 
-        private void UpdateProGuard(string basePath, string proguardUnityTxt) {
+        private static void UpdateProGuard(string basePath, string proguardUnityTxt) {
             string filePath = Path.Combine(basePath, proguardUnityTxt);
             string fileText = File.ReadAllText(filePath);
 

--- a/Assets/AirConsole/scripts/Editor/BuildAutomation/AndroidProjectProcessor.cs
+++ b/Assets/AirConsole/scripts/Editor/BuildAutomation/AndroidProjectProcessor.cs
@@ -1,0 +1,16 @@
+#if !DISABLE_AIRCONSOLE
+namespace NDream.AirConsole.Editor {
+    using UnityEditor.Android;
+
+    public class AndroidProjectProcessor : IPostGenerateGradleAndroidProject {
+        public int callbackOrder {
+            get => 999;
+        }
+
+        public void OnPostGenerateGradleAndroidProject(string projectPath) {
+            AndroidGradleProcessor.Execute(projectPath);
+            AndroidManifestProcessor.Execute(projectPath);
+        }
+    }
+}
+#endif

--- a/Assets/AirConsole/scripts/Editor/BuildAutomation/AndroidProjectProcessor.cs.meta
+++ b/Assets/AirConsole/scripts/Editor/BuildAutomation/AndroidProjectProcessor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 14434a3537884dd6b4ba1a52486e184b
+timeCreated: 1748939901

--- a/Assets/AirConsole/scripts/Editor/PluginDevelopment/DevelopmentTools.cs
+++ b/Assets/AirConsole/scripts/Editor/PluginDevelopment/DevelopmentTools.cs
@@ -19,11 +19,6 @@ namespace NDream.AirConsole.Editor {
             PluginVersionTracker.DeleteLastPluginVersionKey();
         }
 
-        [MenuItem("Tools/AirConsole/Development/Update Android Manifest", false, 41)]
-        public static void UpdateAndroidManifestMenuAction() {
-            AndroidManifestProcessor.UpdateAndroidManifest();
-        }
-
         /// <summary>
         /// Handy little tool required when exceptions in 'EditorApplication.LockReloadAssemblies' blocks freeze assembly reloads
         /// until the next Unity restart.


### PR DESCRIPTION
Integrates AndroidManifest upgrade with exported Android project

Use the Gradle based workflows to access the AndroidManifest.xml after
the export took place to ensure to see the combination of all
PostProcessing steps in Unity as well as AndroidManifest merges from the
different plugins.
