### PR TITLE
. R: Change minimum Unity Versions required

### DIFF
--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
@@ -19,10 +19,10 @@ namespace NDream.AirConsole.Editor {
             string[] versions = Application.unityVersion.Split(".");
             switch (versions[0]) {
                 case "2022": {
-                    (bool versionCheck, bool patchCheck) = SemVerCheck.IfMajorMinorPatchAtLeast(2022, 3, 57, Application.unityVersion);
+                    (bool versionCheck, bool patchCheck) = SemVerCheck.IfMajorMinorPatchAtLeast(2022, 3, 62, Application.unityVersion);
                     if (versionCheck && !patchCheck) {
                         if (invokeErrorOnFail) {
-                            InvokeErrorOrLog("For Android usage, AirConsole requires at least 2022.3.57f1",
+                            InvokeErrorOrLog("For Android usage, AirConsole requires at least 2022.3.62f1 for Android support",
                                 "Unity 2022 version too old", invokeErrorOnFail);
                         }
                     }
@@ -31,9 +31,10 @@ namespace NDream.AirConsole.Editor {
                 }
 
                 case "6000": {
-                    (bool versionCheck, bool patchCheck) = SemVerCheck.IfMajorMinorPatchAtLeast(6000, 0, 36, Application.unityVersion);
+                    (bool versionCheck, bool patchCheck) = SemVerCheck.IfMajorMinorPatchAtLeast(6000, 0, 43, Application.unityVersion);
                     if (versionCheck && !patchCheck) {
-                        InvokeErrorOrLog("For Android usage, AirConsole requires at least 6000.0.36f1",
+                        InvokeErrorOrLog(
+                            "For Android usage, AirConsole requires at least 6000.0.43f1, 6000.1.0f1 or 6000.2.0f1 for Android support",
                             "Unity 6 version too old", invokeErrorOnFail);
                     }
 
@@ -41,9 +42,9 @@ namespace NDream.AirConsole.Editor {
                 }
 
                 default:
-                    if (!SemVerCheck.IsAtLeast(6000, 0, 36, Application.unityVersion)) {
+                    if (!SemVerCheck.IsAtLeast(6000, 0, 43, Application.unityVersion)) {
                         InvokeErrorOrLog(
-                            "For Android usage, AirConsole requires at least Unity 6000.0.36f1",
+                            "For Android usage, AirConsole requires at least Unity 6000.0.43f1",
                             "Unity 6 version too old", invokeErrorOnFail);
                     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 ### Changed
 
 - Unity's WebGL Memory Growth mode is handled more consistently and provides clearer instructions to game developers.
+- Increased minimum Unity versions to 2022.3.62f1 and 6000.0.43f1 to meet Google Play Store (16kb page file) and Automotive (WebRequest security) requirements.
 
 ## [2.6.0] - 2025-08-14
 
@@ -231,4 +232,3 @@ Gameplay rounds are controlled through AirConsole's setActivePlayers API.
 
 - Support for i386 OSX bundle
 - The webview no longer supports rendering on OSX.
-


### PR DESCRIPTION
This fixes 3 issues that outdated Unity versions have:

1. All new Android builds will have support for the [16kb memory page files required by May 1, 2026](https://play.google.com/console/developers/8705165198363233194/app/4976194383245690758/policy-center/issues/4986921157006885005/details)
2. It addresses a WebRequest security aspect that was raised multiple times by Automotive store platforms (https://issuetracker.unity3d.com/issues/android-ios-unitywebrequest-requests-with-unitywebrequest-are-open-for-ssl-proxying)