### PR TITLE
Update Unity Version check logic

### DIFF
--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
@@ -22,15 +22,17 @@ namespace NDream.AirConsole.Editor {
                 // 2022.3.?? -> 2022.3.62f2 first with CVE-2025-59489 fix
                 "2022" => new Version(2022, 3, 62, 2),
                 "6000" => versions[1] switch {
-                    "0" =>
+                    // 6000.0.?? -> 6000.0.58f2 first with CVE-2025-59489 fix
+                    "0" => new Version(6000, 0, 58, 2),
 
-                        // 6000.0.?? -> 6000.0.58f2 first with CVE-2025-59489 fix
-                        new Version(6000, 0, 58, 2),
-                    "1" =>
+                    // 6000.1.?? -> 6000.1.17f1 first with CVE-2025-59489 fix
+                    "1" => new Version(6000, 1, 17, 1),
 
-                        // 6000.1.?? -> 6000.1.17f1 first with CVE-2025-59489 fix
-                        new Version(6000, 1, 17, 1),
-                    _ => new Version(6000, 2, 6, 2)
+                    // 6000.2.?? -> 6000.2.6f2 first with CVE-2025-59489 fix
+                    "2" => new Version(6000, 2, 6, 2),
+
+                    // 6000.3.?? -> 6000.3.0b4 first with CVE-2025-59489 fix but we require official releases
+                    _ => new Version(6000, 3, 0, 1)
                 },
                 _ => new Version(6000, 0, 58, 2)
             };

--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
@@ -1,9 +1,8 @@
+using System;
 #if !DISABLE_AIRCONSOLE
 namespace NDream.AirConsole.Editor {
     using UnityEditor;
     using UnityEngine;
-    using UnityEditor.Build;
-    using System.Text.RegularExpressions;
 
     public abstract class ProjectDependencyCheck {
         [InitializeOnLoadMethod]
@@ -15,44 +14,41 @@ namespace NDream.AirConsole.Editor {
         /// To meet automotive requirements, we need to have certain minimum versions of Unity that have updated dependencies.
         /// To make the game developer experience consistent, we always check for this.
         /// </summary>
-        private static void ValidateUnityVersion(bool invokeErrorOnFail = false) {
-            string[] versions = Application.unityVersion.Split(".");
-            switch (versions[0]) {
-                case "2022": {
-                    (bool versionCheck, bool patchCheck) = SemVerCheck.IfMajorMinorPatchAtLeast(2022, 3, 62, Application.unityVersion);
-                    if (versionCheck && !patchCheck) {
-                        if (invokeErrorOnFail) {
-                            InvokeErrorOrLog("For Android usage, AirConsole requires at least 2022.3.62f1 for Android support",
-                                "Unity 2022 version too old", invokeErrorOnFail);
-                        }
-                    }
+        internal static void ValidateUnityVersion(bool invokeErrorOnFail = false) {
+            string unityVersion = GetUnityVersion();
+            string[] versions = unityVersion.Split(".");
 
-                    break;
-                }
+            Version requiredVersion = versions[0] switch {
+                // 2022.3.?? -> 2022.3.62f2 first with CVE-2025-59489 fix
+                "2022" => new Version(2022, 3, 62, 2),
+                "6000" => versions[1] switch {
+                    "0" =>
 
-                case "6000": {
-                    (bool versionCheck, bool patchCheck) = SemVerCheck.IfMajorMinorPatchAtLeast(6000, 0, 43, Application.unityVersion);
-                    if (versionCheck && !patchCheck) {
-                        InvokeErrorOrLog(
-                            "For Android usage, AirConsole requires at least 6000.0.43f1, 6000.1.0f1 or 6000.2.0f1 for Android support",
-                            "Unity 6 version too old", invokeErrorOnFail);
-                    }
+                        // 6000.0.?? -> 6000.0.58f2 first with CVE-2025-59489 fix
+                        new Version(6000, 0, 58, 2),
+                    "1" =>
 
-                    break;
-                }
+                        // 6000.1.?? -> 6000.1.17f1 first with CVE-2025-59489 fix
+                        new Version(6000, 1, 17, 1),
+                    _ => new Version(6000, 2, 6, 2)
+                },
+                _ => new Version(6000, 0, 58, 2)
+            };
 
-                default:
-                    if (!SemVerCheck.IsAtLeast(6000, 0, 43, Application.unityVersion)) {
-                        InvokeErrorOrLog(
-                            "For Android usage, AirConsole requires at least Unity 6000.0.43f1",
-                            "Unity 6 version too old", invokeErrorOnFail);
-                    }
-
-                    break;
+            if (!SemVerCheck.ValidateUnityVersionMinimum(requiredVersion, unityVersion)) {
+                InvokeErrorOrLog(
+                    $"For security (CVE-2025-59489), AirConsole requires at least Unity {StringFromVersion(requiredVersion)}",
+                    $"Insecure version {unityVersion}", invokeErrorOnFail);
             }
         }
 
         private static void InvokeErrorOrLog(string message, string title, bool shallError = false) {
+#if UNITY_INCLUDE_TESTS
+            if (InvokeErrorOrLogOverride != null) {
+                InvokeErrorOrLogOverride(message, title, shallError);
+                return;
+            }
+#endif
             if (!shallError) {
                 AirConsoleLogger.LogWarning(() => message);
                 return;
@@ -60,54 +56,21 @@ namespace NDream.AirConsole.Editor {
 
             EditorNotificationService.InvokeError(message, false, title);
         }
-    }
 
-    public abstract class SemVerCheck {
-        /// <summary>
-        /// Determines if the specified version is at least the given major, minor, and patch version.
-        /// </summary>
-        /// <param name="major">The minimum required major version.</param>
-        /// <param name="minor">The minimum required minor version.</param>
-        /// <param name="patch">The minimum required patch version.</param>
-        /// <param name="version">The version string to compare, expected in the format "major.minor.patch".</param>
-        /// <returns>
-        /// True if the version is at least the specified major, minor, and patch version; otherwise, false.
-        /// </returns>
-        internal static bool IsAtLeast(int major, int minor, int patch, string version) {
-            (int foundMajor, int foundMinor, int foundPatch) = GetMajorMinorPatchFromVersion(version);
-            return major >= foundMajor && minor >= foundMinor && patch >= foundPatch;
+        private static string StringFromVersion(Version version) => $"{version.Major}.{version.Minor}.{version.Build}f{version.Revision}";
+
+        private static string GetUnityVersion() {
+#if UNITY_INCLUDE_TESTS
+            return UnityVersionProvider?.Invoke() ?? Application.unityVersion;
+#else
+            return Application.unityVersion;
+#endif
         }
 
-        /// <summary>
-        /// Checks if the given version is at least the specified major, minor, and patch version.
-        /// </summary>
-        /// <param name="major">The required major version.</param>
-        /// <param name="minor">The required minor version.</param>
-        /// <param name="patch">The required patch version.</param>
-        /// <param name="version">The version string to check, expected in the format "major.minor.patch".</param>
-        /// <returns>
-        /// A tuple where the first value indicates if the major and minor versions match,
-        /// and the second value indicates if the patch version is at least the required value.
-        /// </returns>
-        internal static (bool, bool) IfMajorMinorPatchAtLeast(int major, int minor, int patch, string version) {
-            (int foundMajor, int foundMinor, int foundPatch) = GetMajorMinorPatchFromVersion(version);
-
-            if (foundMajor != major || foundMinor != minor) {
-                return (false, false);
-            }
-
-            return (true, foundPatch >= patch);
-        }
-
-        private static (int, int, int) GetMajorMinorPatchFromVersion(string version) {
-            Regex versionExtractor = new("^(?<Major>\\d{4})\\.(?<Minor>\\d+)\\.(?<Patch>\\d+)f\\d+$");
-            Match match = versionExtractor.Match(version);
-            if (!match.Success) {
-                throw new BuildFailedException("No valid version found ");
-            }
-
-            return (int.Parse(match.Groups["Major"].Value), int.Parse(match.Groups["Minor"].Value), int.Parse(match.Groups["Patch"].Value));
-        }
+#if UNITY_INCLUDE_TESTS
+        internal static Func<string>? UnityVersionProvider;
+        internal static Action<string, string, bool>? InvokeErrorOrLogOverride;
+#endif
     }
 }
 #endif

--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/ProjectDependencyCheck.cs
@@ -1,8 +1,8 @@
-using System;
 #if !DISABLE_AIRCONSOLE
 namespace NDream.AirConsole.Editor {
     using UnityEditor;
     using UnityEngine;
+    using System;
 
     public abstract class ProjectDependencyCheck {
         [InitializeOnLoadMethod]

--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs
@@ -5,9 +5,6 @@ using UnityEditor.Build;
 
 namespace NDream.AirConsole.Editor {
     internal abstract class SemVerCheck {
-#if UNITY_INCLUDE_TESTS
-        internal static Func<Version, string, bool>? ValidateUnityVersionMinimumOverride;
-#endif
         /// <summary>
         /// Validates that Unity matches a required minimum version.
         /// </summary>
@@ -15,11 +12,6 @@ namespace NDream.AirConsole.Editor {
         /// <param name="detectedVersion">The version string to check, expected in the format "major.minor.patch".</param>
         /// <returns> True, if the detected version is greater than or equal to the required version.</returns>
         internal static bool ValidateUnityVersionMinimum(Version requiredVersion, string detectedVersion) {
-#if UNITY_INCLUDE_TESTS
-            if (ValidateUnityVersionMinimumOverride != null) {
-                return ValidateUnityVersionMinimumOverride(requiredVersion, detectedVersion);
-            }
-#endif
             Version foundVersion = GetMajorMinorPatchFromVersion(detectedVersion);
             return foundVersion.CompareTo(requiredVersion) >= 0;
         }

--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs
@@ -1,0 +1,44 @@
+#if !DISABLE_AIRCONSOLE
+using System;
+using System.Text.RegularExpressions;
+using UnityEditor.Build;
+
+namespace NDream.AirConsole.Editor {
+    internal abstract class SemVerCheck {
+#if UNITY_INCLUDE_TESTS
+        internal static Func<Version, string, bool>? ValidateUnityVersionMinimumOverride;
+#endif
+        /// <summary>
+        /// Validates that Unity matches a required minimum version.
+        /// </summary>
+        /// <param name="requiredVersion">The required version. We use Version to form Unity's version string of MAJOR.MINOR.BUILDfREVISION</param>
+        /// <param name="detectedVersion">The version string to check, expected in the format "major.minor.patch".</param>
+        /// <returns> True, if the detected version is greater than or equal to the required version.</returns>
+        internal static bool ValidateUnityVersionMinimum(Version requiredVersion, string detectedVersion) {
+#if UNITY_INCLUDE_TESTS
+            if (ValidateUnityVersionMinimumOverride != null) {
+                return ValidateUnityVersionMinimumOverride(requiredVersion, detectedVersion);
+            }
+#endif
+            Version foundVersion = GetMajorMinorPatchFromVersion(detectedVersion);
+            return foundVersion.CompareTo(requiredVersion) >= 0;
+        }
+
+        private static Version GetMajorMinorPatchFromVersion(string version) {
+            Regex versionExtractor = new(@"^(?<Major>\d{4})\.(?<Minor>\d+)\.(?<Build>\d+)f(?<Revision>\d+)$");
+            Match match = versionExtractor.Match(version);
+            if (!match.Success) {
+                throw new BuildFailedException(
+                    "No valid Unity Application version found. Format should be <MAJOR>.<MINOR>.<BUILD>f<REVISION>");
+            }
+
+            return new Version(
+                int.Parse(match.Groups["Major"].Value),
+                int.Parse(match.Groups["Minor"].Value),
+                int.Parse(match.Groups["Build"].Value),
+                int.Parse(match.Groups["Revision"].Value)
+            );
+        }
+    }
+}
+#endif

--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs
@@ -1,9 +1,9 @@
 #if !DISABLE_AIRCONSOLE
-using System;
-using System.Text.RegularExpressions;
-using UnityEditor.Build;
-
 namespace NDream.AirConsole.Editor {
+    using System;
+    using System.Text.RegularExpressions;
+    using UnityEditor.Build;
+    
     internal abstract class SemVerCheck {
         /// <summary>
         /// Validates that Unity matches a required minimum version.

--- a/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs.meta
+++ b/Assets/AirConsole/scripts/Editor/ProjectMaintenance/SemVerCheck.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 111f68ef338d4a43b5825385fcf7f192
+timeCreated: 1759739181

--- a/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
+++ b/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
@@ -1,11 +1,10 @@
 #if !DISABLE_AIRCONSOLE
-using System;
-using NUnit.Framework;
-using UnityEditor.Build;
-using UnityEngine;
-using UnityEngine.TestTools;
-
 namespace NDream.AirConsole.Editor.Tests {
+    using NUnit.Framework;
+    using UnityEditor.Build;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    
     public class ProjectDependencyCheckTests {
         [TearDown]
         public void TearDown() {

--- a/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
+++ b/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
@@ -1,6 +1,7 @@
 #if !DISABLE_AIRCONSOLE
 using System;
 using NUnit.Framework;
+using UnityEditor.Build;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -10,41 +11,33 @@ namespace NDream.AirConsole.Editor.Tests {
         public void TearDown() {
             ProjectDependencyCheck.UnityVersionProvider = null;
             ProjectDependencyCheck.InvokeErrorOrLogOverride = null;
-            SemVerCheck.ValidateUnityVersionMinimumOverride = null;
         }
 
-        [TestCase("2022.3.99f1", 2022, 3, 62, 2)]
-        [TestCase("6000.0.99f1", 6000, 0, 58, 2)]
-        [TestCase("6000.1.20f5", 6000, 1, 17, 1)]
-        [TestCase("6000.2.5f1", 6000, 2, 6, 2)]
-        [TestCase("2030.1.5f1", 6000, 0, 58, 2)]
-        public void ValidateUnityVersion_PassesExpectedRequiredVersion(string unityVersion, int expectedMajor, int expectedMinor,
-            int expectedBuild, int expectedRevision) {
-            Version? capturedRequired = null;
-            string? capturedDetectedVersion = null;
-            SemVerCheck.ValidateUnityVersionMinimumOverride = (required, detected) => {
-                capturedRequired = required;
-                capturedDetectedVersion = detected;
-                return true;
-            };
+        [TestCase("2022.3.62f2")]
+        [TestCase("2022.3.62f3")]
+        [TestCase("2022.3.99f1")]
+        [TestCase("6000.0.99f1")]
+        [TestCase("6000.1.20f5")]
+        [TestCase("6000.2.6f2")]
+        [TestCase("6000.3.0f1")]
+        [TestCase("6001.0.0f1")]
+        public void ValidateUnityVersion_PassesExpectedRequiredVersion(string unityVersion) {
+            bool handlerInvoked = false;
+
             ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
+            ProjectDependencyCheck.InvokeErrorOrLogOverride = (_, _, _) => { handlerInvoked = true; };
 
             ProjectDependencyCheck.ValidateUnityVersion();
 
-            Assert.That(capturedDetectedVersion, Is.EqualTo(unityVersion));
-            Assert.That(capturedRequired, Is.Not.Null);
-            Assert.That(capturedRequired, Is.EqualTo(new Version(expectedMajor, expectedMinor, expectedBuild, expectedRevision)));
+
+            Assert.That(handlerInvoked, Is.False);
         }
 
-        [Test]
-        public void ValidateUnityVersion_WhenBelowMinimum_LogsWarning() {
-            const string unityVersion = "6000.0.1f1";
-            string expectedMessage = "For security (CVE-2025-59489), AirConsole requires at least Unity 6000.0.58f2";
-            SemVerCheck.ValidateUnityVersionMinimumOverride = (required, detected) => {
-                Assert.That(required, Is.EqualTo(new Version(6000, 0, 58, 2)));
-                Assert.That(detected, Is.EqualTo(unityVersion));
-                return false;
-            };
+        [TestCase("6000.1.12f1")]
+        public void ValidateUnityVersion_WhenBelowMinimum_LogsWarning(string unityVersion) {
+            const string expectedRequired = "6000.1.17f1";
+            string expectedMessage = $"For security (CVE-2025-59489), AirConsole requires at least Unity {expectedRequired}";
+
             ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
 
             LogAssert.Expect(LogType.Warning, expectedMessage);
@@ -54,17 +47,24 @@ namespace NDream.AirConsole.Editor.Tests {
             LogAssert.NoUnexpectedReceived();
         }
 
-        [Test]
-        public void ValidateUnityVersion_WhenBelowMinimumAndErrorRequested_InvokesErrorHandler() {
-            const string unityVersion = "6000.1.5f1";
-            Version? capturedRequired = null;
-            const string expectedRequired = "6000.1.17f1";
+        [TestCase("6000.3.0b4")]
+        public void ValidateUnityVersion_WhenInBeta_ThrowsBuildFailed(string unityVersion) {
+            ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
+
+            Assert.Throws<BuildFailedException>(() => ProjectDependencyCheck.ValidateUnityVersion(false),
+                "UnityEditor.Build.BuildFailedException : No valid Unity Application version found. Format should be <MAJOR>.<MINOR>.<BUILD>f<REVISION>");
+        }
+
+        [TestCase("2022.3.61f1", "2022.3.62f2")]
+        [TestCase("2022.3.62f1", "2022.3.62f2")]
+        [TestCase("6000.0.57f1", "6000.0.58f2")]
+        [TestCase("6000.0.58f1", "6000.0.58f2")]
+        [TestCase("6000.1.16f1", "6000.1.17f1")]
+        [TestCase("6000.2.5f1", "6000.2.6f2")]
+        public void ValidateUnityVersion_WhenBelowMinimumAndErrorRequested_InvokesErrorHandler(string unityVersion,
+            string expectedRequired) {
             bool handlerInvoked = false;
-            SemVerCheck.ValidateUnityVersionMinimumOverride = (required, detected) => {
-                capturedRequired = required;
-                Assert.That(detected, Is.EqualTo(unityVersion));
-                return false;
-            };
+
             ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
             ProjectDependencyCheck.InvokeErrorOrLogOverride = (message, title, shallError) => {
                 handlerInvoked = true;
@@ -76,7 +76,6 @@ namespace NDream.AirConsole.Editor.Tests {
             ProjectDependencyCheck.ValidateUnityVersion(true);
 
             Assert.That(handlerInvoked, Is.True);
-            Assert.That(capturedRequired, Is.EqualTo(new Version(6000, 1, 17, 1)));
             LogAssert.NoUnexpectedReceived();
         }
     }

--- a/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
+++ b/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
@@ -32,9 +32,13 @@ namespace NDream.AirConsole.Editor.Tests {
             Assert.That(handlerInvoked, Is.False);
         }
 
-        [TestCase("6000.1.12f1")]
-        public void ValidateUnityVersion_WhenBelowMinimum_LogsWarning(string unityVersion) {
-            const string expectedRequired = "6000.1.17f1";
+        [TestCase("2022.3.61f1", "2022.3.62f2")]
+        [TestCase("2022.3.62f1", "2022.3.62f2")]
+        [TestCase("6000.0.57f1", "6000.0.58f2")]
+        [TestCase("6000.0.58f1", "6000.0.58f2")]
+        [TestCase("6000.1.16f1", "6000.1.17f1")]
+        [TestCase("6000.2.5f1", "6000.2.6f2")]
+        public void ValidateUnityVersion_WhenBelowMinimum_LogsWarning(string unityVersion, string expectedRequired) {
             string expectedMessage = $"For security (CVE-2025-59489), AirConsole requires at least Unity {expectedRequired}";
 
             ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;

--- a/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
+++ b/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs
@@ -1,0 +1,84 @@
+#if !DISABLE_AIRCONSOLE
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace NDream.AirConsole.Editor.Tests {
+    public class ProjectDependencyCheckTests {
+        [TearDown]
+        public void TearDown() {
+            ProjectDependencyCheck.UnityVersionProvider = null;
+            ProjectDependencyCheck.InvokeErrorOrLogOverride = null;
+            SemVerCheck.ValidateUnityVersionMinimumOverride = null;
+        }
+
+        [TestCase("2022.3.99f1", 2022, 3, 62, 2)]
+        [TestCase("6000.0.99f1", 6000, 0, 58, 2)]
+        [TestCase("6000.1.20f5", 6000, 1, 17, 1)]
+        [TestCase("6000.2.5f1", 6000, 2, 6, 2)]
+        [TestCase("2030.1.5f1", 6000, 0, 58, 2)]
+        public void ValidateUnityVersion_PassesExpectedRequiredVersion(string unityVersion, int expectedMajor, int expectedMinor,
+            int expectedBuild, int expectedRevision) {
+            Version? capturedRequired = null;
+            string? capturedDetectedVersion = null;
+            SemVerCheck.ValidateUnityVersionMinimumOverride = (required, detected) => {
+                capturedRequired = required;
+                capturedDetectedVersion = detected;
+                return true;
+            };
+            ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
+
+            ProjectDependencyCheck.ValidateUnityVersion();
+
+            Assert.That(capturedDetectedVersion, Is.EqualTo(unityVersion));
+            Assert.That(capturedRequired, Is.Not.Null);
+            Assert.That(capturedRequired, Is.EqualTo(new Version(expectedMajor, expectedMinor, expectedBuild, expectedRevision)));
+        }
+
+        [Test]
+        public void ValidateUnityVersion_WhenBelowMinimum_LogsWarning() {
+            const string unityVersion = "6000.0.1f1";
+            string expectedMessage = "For security (CVE-2025-59489), AirConsole requires at least Unity 6000.0.58f2";
+            SemVerCheck.ValidateUnityVersionMinimumOverride = (required, detected) => {
+                Assert.That(required, Is.EqualTo(new Version(6000, 0, 58, 2)));
+                Assert.That(detected, Is.EqualTo(unityVersion));
+                return false;
+            };
+            ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
+
+            LogAssert.Expect(LogType.Warning, expectedMessage);
+
+            ProjectDependencyCheck.ValidateUnityVersion(false);
+
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void ValidateUnityVersion_WhenBelowMinimumAndErrorRequested_InvokesErrorHandler() {
+            const string unityVersion = "6000.1.5f1";
+            Version? capturedRequired = null;
+            const string expectedRequired = "6000.1.17f1";
+            bool handlerInvoked = false;
+            SemVerCheck.ValidateUnityVersionMinimumOverride = (required, detected) => {
+                capturedRequired = required;
+                Assert.That(detected, Is.EqualTo(unityVersion));
+                return false;
+            };
+            ProjectDependencyCheck.UnityVersionProvider = () => unityVersion;
+            ProjectDependencyCheck.InvokeErrorOrLogOverride = (message, title, shallError) => {
+                handlerInvoked = true;
+                Assert.That(shallError, Is.True);
+                Assert.That(message, Is.EqualTo($"For security (CVE-2025-59489), AirConsole requires at least Unity {expectedRequired}"));
+                Assert.That(title, Is.EqualTo($"Insecure version {unityVersion}"));
+            };
+
+            ProjectDependencyCheck.ValidateUnityVersion(true);
+
+            Assert.That(handlerInvoked, Is.True);
+            Assert.That(capturedRequired, Is.EqualTo(new Version(6000, 1, 17, 1)));
+            LogAssert.NoUnexpectedReceived();
+        }
+    }
+}
+#endif

--- a/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs.meta
+++ b/Assets/AirConsole/scripts/Tests/Editor/ProjectDependencyCheckTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a099e71b9f7f4e0f91a1d02767fcbfcb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Changed
+
+- Minimum Versions: The Unity minimum versions have been updated to match `CVE-2025-59489` fix versions.
+
 ### Removed
 
 - **Android**: The android library no longer manages AudioFocus or overriding the usage from USAGE_GAME.


### PR DESCRIPTION
* Validate the full version string to include revisions.
* Validate 2022.3, 6000.0, 6000.1 and 6000.2 to ensure CVE-2025-59489 compliance.