### PR TITLE
ENG-2717: Send androidAppVersion in Android webview URL

### DIFF
--- a/Assets/AirConsole/scripts/Runtime/AirConsole.cs
+++ b/Assets/AirConsole/scripts/Runtime/AirConsole.cs
@@ -2248,27 +2248,22 @@ namespace NDream.AirConsole {
                     _pluginManager.InitializeOfflineCheck();
                 }
 
-                string url;
+                string baseUrl;
                 if (IsAndroidRuntime) {
                     string urlOverride = AndroidIntentUtils.GetIntentExtraString("base_url", string.Empty);
-                    url = !string.IsNullOrEmpty(urlOverride) ? urlOverride : Settings.AIRCONSOLE_BASE_URL;
+                    baseUrl = !string.IsNullOrEmpty(urlOverride) ? urlOverride : Settings.AIRCONSOLE_BASE_URL;
                     AirConsoleLogger.LogDevelopment(() => $"BaseURL Override: {urlOverride}");
                 } else {
-                    url = Settings.AIRCONSOLE_BASE_URL;
-                }
-
-                url += connectionUrl;
-                if (IsAndroidRuntime) {
-                    url += $"&bundle-version={GetAndroidBundleVersionCode()}";
+                    baseUrl = Settings.AIRCONSOLE_BASE_URL;
                 }
 
                 androidGameVersion = AndroidIntentUtils.GetIntentExtraString("game_version", androidGameVersion);
-
-                url += "&game-id=" + Application.identifier;
-                url += "&game-version=" + androidGameVersion;
-                url += "&unity-version=" + Application.unityVersion;
                 bool nativeSizingSupported = ResolveNativeGameSizingSupport(nativeGameSizingSupported);
-                url += nativeSizingSupported ? "&supportsNativeGameSizing=true" : "&supportsNativeGameSizing=false";
+
+                string url = BuildWebviewUrl(
+                    baseUrl, connectionUrl, IsAndroidRuntime,
+                    IsAndroidRuntime ? GetAndroidBundleVersionCode() : 0, Application.version,
+                    Application.identifier, androidGameVersion, Application.unityVersion, nativeSizingSupported);
 
                 defaultScreenHeight = Screen.height;
                 _webViewOriginalUrl = url;
@@ -2305,6 +2300,28 @@ namespace NDream.AirConsole {
         private static bool ResolveNativeGameSizingSupport(bool fallback) {
             AirconsoleRuntimeSettings settings = Resources.Load<AirconsoleRuntimeSettings>(AirconsoleRuntimeSettings.ResourceName);
             return settings ? settings.NativeGameSizingSupported : fallback;
+        }
+
+        /// <summary>
+        /// Assembles the query string appended to the AirConsole webview URL.
+        /// Pure and free of device dependencies so both the Android and Web paths are unit-testable:
+        /// the caller passes device-derived values (bundle version code, app version, ...).
+        /// The <c>bundle-version</c> and <c>androidAppVersion</c> parameters are only added on the Android runtime.
+        /// </summary>
+        internal static string BuildWebviewUrl(string baseUrl, string connectionUrl, bool isAndroidRuntime,
+            int bundleVersionCode, string appVersion, string gameId, string gameVersion, string unityVersion,
+            bool nativeSizingSupported) {
+            string url = baseUrl + connectionUrl;
+            if (isAndroidRuntime) {
+                url += $"&bundle-version={bundleVersionCode}";
+                url += $"&androidAppVersion={appVersion}";
+            }
+
+            url += "&game-id=" + gameId;
+            url += "&game-version=" + gameVersion;
+            url += "&unity-version=" + unityVersion;
+            url += nativeSizingSupported ? "&supportsNativeGameSizing=true" : "&supportsNativeGameSizing=false";
+            return url;
         }
 
         private static int GetAndroidBundleVersionCode() {

--- a/Assets/AirConsole/scripts/Tests/PlayMode/AndroidWebviewUrlTests.cs
+++ b/Assets/AirConsole/scripts/Tests/PlayMode/AndroidWebviewUrlTests.cs
@@ -9,7 +9,10 @@ namespace NDream.AirConsole.PlayMode.Tests {
     /// </summary>
     public class AndroidWebviewUrlTests {
         private const string BaseUrl = "https://www.airconsole.com/";
-        private const string ConnectionUrl = "?id=5";
+
+        // Mirrors the real connection URL built in AirConsole.InitWebView: a path plus its own query start,
+        // e.g. "client?id=androidunity-2.62&runtimePlatform=android". The '?' is mid-string, not leading.
+        private const string ConnectionUrl = "client?id=androidunity-2.62&runtimePlatform=android";
         private const string AppVersion = "1.2.3";
         private const int BundleVersionCode = 42;
         private const string GameId = "com.example.game";
@@ -73,8 +76,8 @@ namespace NDream.AirConsole.PlayMode.Tests {
             string url = AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, isAndroidRuntime, BundleVersionCode,
                 AppVersion, GameId, GameVersion, UnityVersion, true);
 
-            Assert.AreEqual(BaseUrl.Length, url.IndexOf('?'), "URL must contain exactly the connection-url query start.");
-            Assert.AreEqual(1, url.Split('?').Length - 1, "URL must contain exactly one '?'.");
+            StringAssert.StartsWith(BaseUrl + ConnectionUrl, url, "URL must begin with the base and connection URL unchanged.");
+            Assert.AreEqual(1, url.Split('?').Length - 1, "URL must contain exactly one '?' (the connection URL query start).");
             Assert.IsFalse(url.Contains("&&"), "URL must not contain empty parameters (&&).");
             Assert.IsFalse(url.Contains("=&"), "URL must not contain dangling parameters (=&).");
             Assert.IsFalse(url.EndsWith("="), "URL must not end with a dangling '='.");

--- a/Assets/AirConsole/scripts/Tests/PlayMode/AndroidWebviewUrlTests.cs
+++ b/Assets/AirConsole/scripts/Tests/PlayMode/AndroidWebviewUrlTests.cs
@@ -1,0 +1,94 @@
+#if !DISABLE_AIRCONSOLE
+using NUnit.Framework;
+
+namespace NDream.AirConsole.PlayMode.Tests {
+    /// <summary>
+    /// Covers <see cref="AirConsole.BuildWebviewUrl"/>, the pure query-string builder behind the Android webview URL.
+    /// Exercises the Android vs Web runtime paths deterministically without a device: the Android-only parameters
+    /// (<c>bundle-version</c>, <c>androidAppVersion</c>) must appear only when <c>isAndroidRuntime</c> is true.
+    /// </summary>
+    public class AndroidWebviewUrlTests {
+        private const string BaseUrl = "https://www.airconsole.com/";
+        private const string ConnectionUrl = "?id=5";
+        private const string AppVersion = "1.2.3";
+        private const int BundleVersionCode = 42;
+        private const string GameId = "com.example.game";
+        private const string GameVersion = "7";
+        private const string UnityVersion = "2022.3.62f1";
+
+        private static string BuildAndroid() =>
+            AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, true, BundleVersionCode, AppVersion, GameId,
+                GameVersion, UnityVersion, true);
+
+        private static string BuildWeb() =>
+            AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, false, BundleVersionCode, AppVersion, GameId,
+                GameVersion, UnityVersion, true);
+
+        [Test]
+        public void AndroidPath_AddsAndroidAppVersion() {
+            StringAssert.Contains($"&androidAppVersion={AppVersion}", BuildAndroid());
+        }
+
+        [Test]
+        public void AndroidPath_AddsBundleVersion() {
+            StringAssert.Contains($"&bundle-version={BundleVersionCode}", BuildAndroid());
+        }
+
+        [Test]
+        public void WebPath_OmitsAndroidAppVersion() {
+            Assert.IsFalse(BuildWeb().Contains("androidAppVersion"),
+                "Web runtime URL must not carry the Android-only androidAppVersion parameter.");
+        }
+
+        [Test]
+        public void WebPath_OmitsBundleVersion() {
+            Assert.IsFalse(BuildWeb().Contains("bundle-version"),
+                "Web runtime URL must not carry the Android-only bundle-version parameter.");
+        }
+
+        [Test]
+        public void SharedParams_PresentOnBothPaths([Values(true, false)] bool isAndroidRuntime) {
+            string url = AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, isAndroidRuntime, BundleVersionCode,
+                AppVersion, GameId, GameVersion, UnityVersion, true);
+
+            StringAssert.Contains($"&game-id={GameId}", url);
+            StringAssert.Contains($"&game-version={GameVersion}", url);
+            StringAssert.Contains($"&unity-version={UnityVersion}", url);
+            StringAssert.Contains("&supportsNativeGameSizing=true", url);
+        }
+
+        [Test]
+        public void NativeGameSizing_ReflectsSupportFlag() {
+            string supported = AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, true, BundleVersionCode, AppVersion,
+                GameId, GameVersion, UnityVersion, true);
+            string unsupported = AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, true, BundleVersionCode, AppVersion,
+                GameId, GameVersion, UnityVersion, false);
+
+            StringAssert.Contains("&supportsNativeGameSizing=true", supported);
+            StringAssert.Contains("&supportsNativeGameSizing=false", unsupported);
+        }
+
+        [Test]
+        public void QueryString_IsWellFormed([Values(true, false)] bool isAndroidRuntime) {
+            string url = AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, isAndroidRuntime, BundleVersionCode,
+                AppVersion, GameId, GameVersion, UnityVersion, true);
+
+            Assert.AreEqual(BaseUrl.Length, url.IndexOf('?'), "URL must contain exactly the connection-url query start.");
+            Assert.AreEqual(1, url.Split('?').Length - 1, "URL must contain exactly one '?'.");
+            Assert.IsFalse(url.Contains("&&"), "URL must not contain empty parameters (&&).");
+            Assert.IsFalse(url.Contains("=&"), "URL must not contain dangling parameters (=&).");
+            Assert.IsFalse(url.EndsWith("="), "URL must not end with a dangling '='.");
+        }
+
+        [Test]
+        public void AppVersion_IsSourceOfAndroidAppVersion_NotGameVersion() {
+            // Guards against wiring androidAppVersion to the wrong field (e.g. game-version).
+            string url = AirConsole.BuildWebviewUrl(BaseUrl, ConnectionUrl, true, BundleVersionCode, "9.9", GameId,
+                "1", UnityVersion, true);
+
+            StringAssert.Contains("&androidAppVersion=9.9", url);
+            StringAssert.Contains("&game-version=1", url);
+        }
+    }
+}
+#endif

--- a/Assets/AirConsole/scripts/Tests/PlayMode/AndroidWebviewUrlTests.cs.meta
+++ b/Assets/AirConsole/scripts/Tests/PlayMode/AndroidWebviewUrlTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67395bc3c64714e59be9a7059aac6c29
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This includes security related updates like requiring fixed Unity versions and i
 - **Unity API:** `OnMaximumVolumeChanged` event to notify when the games maximum volume must be changed.
 - **Android:** After the last device disconnects, the webview is reset along the game state.
 - **Android:** Add support to override the game version used in a previously built android game through intent extras with adb.
+- **Android:** The Android application version is now reported to the platform through the webview URL.
 - **Android:** The support for native game sizing is communicated
 - **Android Audio Focus:** Improvements to match the expected behavior on Android Automotive.
 - **Android Audio Focus:** Drive maximum volume based on Android system requirements to avoid pausing when losing audio focus.

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.62f2
-m_EditorVersionWithRevision: 2022.3.62f2 (7670c08855a9)
+m_EditorVersion: 2022.3.62f3
+m_EditorVersionWithRevision: 2022.3.62f3 (96770f904ca7)


### PR DESCRIPTION
## What

- Append `androidAppVersion={Application.version}` to the Android webview URL, alongside the existing `bundle-version` (Android-runtime only).
- Extract the URL query-string assembly out of `CreateAndroidWebview` into a pure, device-independent `BuildWebviewUrl` seam so the Android and Web paths can be tested without a device.
- Add PlayMode tests (`AndroidWebviewUrlTests`) covering both paths: Android-only params present on Android, absent on Web, shared params on both, well-formed query string, and correct field mapping.
- Pin the project to Unity `2022.3.62f3`.

## Why

Report the Android application version to the platform for version tracking, matching the parameter already sent by the Automotive AirConsole Player.

## Scope

- In: `androidAppVersion` parameter, a behavior-preserving testability refactor, PlayMode tests, Unity version pin.
- Out of scope: any change to the Web/WebGL URL parameters.

## Testing

- PlayMode suite run locally on the Android build target (Unity 2022.3.62f3): 10/10 passed.
- Note: run headless tests with `-buildTarget Android` — `CheckPlatform` (`[InitializeOnLoadMethod]`) switches the build target on load, which segfaults in batchmode when starting from a non-Android/WebGL target.
